### PR TITLE
Fixed image paths so they work from main page or post page

### DIFF
--- a/monkblog/blueprints/model_blueprint.py
+++ b/monkblog/blueprints/model_blueprint.py
@@ -35,6 +35,7 @@ def post_from_db(slug):
                                 post=post_object,
                                 bootstrap_theme=bootstrap_theme)
 
+@model_blueprint.route('/posts/posts/images/<filename>')
 @model_blueprint.route('/posts/images/<filename>')
 def post_image(filename):
     return redirect('/static/markdown/posts/images/' + filename)

--- a/monkblog/static/markdown/atom_line-ending-selector.md
+++ b/monkblog/static/markdown/atom_line-ending-selector.md
@@ -2,7 +2,7 @@
 
 # Atom line-ending-selector error
 
-<a href='http://www.atom.io'><img class='img-responsive atom-logo' src='./posts/images/atomeditor.png' alt="Get Atom!"/></a>
+<a href='http://www.atom.io'><img class='img-responsive atom-logo' src='posts/images/atomeditor.png' alt="Get Atom!"/></a>
 
 Today I installed the beautiful [Atom editor](http://www.atom.io/) on my Ubuntu 14.10 system.
 
@@ -35,9 +35,7 @@ To open the console, click: `View > Developer > Toggle Developer Tools`.
 <br/>
 
 <figure class="figure center-block">
-    <a href="./images/atom_devconsole.png">
-        <img class='img-responsive' src="./posts/images/atom_devconsole.png" />
-    </a>
+    <img class='img-responsive' src="posts/images/atom_devconsole.png" />
     <figcaption class="figure-caption">
         The Atom developer console - select the Sources tab.
     </figcaption>
@@ -65,4 +63,4 @@ But I found a workaround that is working perfectly for me: [build Atom from sour
 Yes, I hear you saying this in the back of your head.
 But believe me, it's a pretty painless process.
 
-For more details, check out my post about [Building Atom from source](/markdown/build_atom).
+For more details, check out my post about [Building Atom from source](/posts/Build_Atom).

--- a/monkblog/static/markdown/build_atom.md
+++ b/monkblog/static/markdown/build_atom.md
@@ -2,7 +2,7 @@
 
 # Building Atom From Source
 
-<a href='http://www.atom.io'><img class='img-responsive atom-logo' src='./posts/images/atomeditor.png' alt="Get Atom!"/></a>
+<a href='http://www.atom.io'><img class='img-responsive atom-logo' src='posts/images/atomeditor.png' alt="Get Atom!"/></a>
 
 
 In [my previous post](/markdown/atom) I came to the conclusion that I needed some kind of workaround to fix my Atom installation on Ubuntu.

--- a/monkblog/static/markdown/proposal.md
+++ b/monkblog/static/markdown/proposal.md
@@ -1,6 +1,6 @@
 
 <h1>Dashboard/OEE Project</h1>
-<img class='img-responsive' src='./posts/images/dashboard.png'/>
+<img class='img-responsive' src='posts/images/dashboard.png'/>
 
 ## Background ##
 KPIs derived from NOV's current data sources are inaccurate.
@@ -13,11 +13,9 @@ NOV can undertake a series of projects to automatically gather accurate info, an
 
 ## Example Features ##
 
-<center>
-    <img src='./posts/images/VIMANA_Screen_3.png' />
-    <img src='./posts/images/vimana_mobile.png' style="width: 20%" />
-    <img src='./posts/images/downtime.png' />
-</center>
+<img class='img-responsive' src='posts/images/VIMANA_Screen_3.png' />
+<img class='img-responsive' src='posts/images/vimana_mobile.png' style="width: 20%" />
+<img class='img-responsive' src='posts/images/downtime.png' />
 
 ## Scope ##
 The end result of the project is a package of software & hardware that can be deployed at any manufacturing facility in NOV.


### PR DESCRIPTION
Image paths are causing a huge headache. Patch for now to make images load whether posts are viewed from / or /posts/<slug>.
